### PR TITLE
Have set-permissions set its own, as well

### DIFF
--- a/set-permissions.sh
+++ b/set-permissions.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+chmod +x set-permissions.sh
 chmod +x createThumbnail.js
 chmod +x desktopicons-neo.js
 chmod +x export-zip.sh


### PR DESCRIPTION
This way, it will be covered if a user runs it first-time with just:
```sh
$ sh ./set-permissions.sh

$ . ./set-permissions.sh
```
etc...

(Not that they're likely to need to run it _again_, but what's the harm?)