### PR TITLE
Added desktop-icons-neo to the AUR and updated the README accordingly 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ ninja -C .build install
 
 It's possible to read more information in the Meson docs to tweak the configuration if needed.
 
+## Install from the AUR
+
+Arch-Linux users can install the extension with the [gnome-shell-extension-desktop-icons-neo AUR package](https://aur.archlinux.org/packages/gnome-shell-extension-desktop-icons-neo).
+
 ## Export extension ZIP file for extensions.gnome.org
 
 To create a ZIP file of the project certified for use on extensions.gnome.org, run:


### PR DESCRIPTION
Hi,

First of all, congratulations for your awesome work with `desktop-icons-neo`.

I added the extension to the [AUR](https://wiki.archlinux.org/title/Arch_User_Repository) so Arch-Linux users (and Arch-Linux based distros users globally) can benefit from an easy and centralised install/update process. I hope you're okay with that.
You can review its PKGBUILD [here](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=gnome-shell-extension-desktop-icons-neo)

Of course, I'm down to maintain the [gnome-shell-extension-desktop-icons-neo AUR package](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=gnome-shell-extension-desktop-icons-neo) for all the future updates `desktop-icons-neo` will get :smile:

I thought it could be cool to indicate to people that `desktop-icons-neo` is now available on the AUR as well, hence this PR.

Obviously, I would totally understand if you refuse this PR because you don't specifically want to promote a community packaged `desktop-icons-neo`, but as you can see in the [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=gnome-shell-extension-desktop-icons-neo), it basically just build the extension with MESON according to [the given instructions in the README](https://github.com/DEM0NAssissan7/desktop-icons-neo#build-with-meson).

I remain available if you need any additional information!

And thanks once again for your great work :)