### PR TITLE
Add support for GNOME 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
       "3.38",
       "40",
       "41",
-      "42"
+      "42",
+      "43"
     ],
     "uuid": "desktopicons-neo@darkdemon",
     "url": "https://github.com/DEM0NAssissan7/desktop-icons-neo",


### PR DESCRIPTION
Similar issue as defined here:
https://github.com/DEM0NAssissan7/desktop-icons-neo/issues/26

Looks like GNOME 43 works just fine, but needs to be updated in the metadata.json.

Tested in GNOME 43, Fedora 37.